### PR TITLE
Made tool more available

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/Dojo.AutoGenerators/AutoInterfaceGenerator.cs
+++ b/Dojo.AutoGenerators/AutoInterfaceGenerator.cs
@@ -43,7 +43,7 @@ namespace Dojo.AutoGenerators
                     args.Add(arg.ToString());
                 }
 
-                bdr.AppendJoin(", ", args);
+                bdr.Append(string.Join(", ", args));
                 bdr.Append('>');
             }
 

--- a/Dojo.AutoGenerators/Dojo.AutoGenerators.csproj
+++ b/Dojo.AutoGenerators/Dojo.AutoGenerators.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <!-- Package the generator in the analyzer directory of the nuget package -->
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-    <None Include="$(OutputPath)\Dojo.Generators.Abstractions.dll" Pack="true" PackagePath="lib/netstandard2.1/Dojo.Generators.Abstractions.dll" Visible="false" />
+    <None Include="$(OutputPath)\Dojo.Generators.Abstractions.dll" Pack="true" PackagePath="lib/$(TargetFramework)/Dojo.Generators.Abstractions.dll" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**What does this PR do?**
Makes this tool more available - to most of the platforms supported today (.net core, framework, .net, etc...).
Main motivator for that is VS 2019 support (which runs on .net framework) and can't load  `netstandard2.1` assemblies.

Running on  `netstandard2.0` covers all the needs.

**How does the PR achieve that?**
Downgrades from `netstandard2.1` to `netstandard2.0.`

**How do I test this?**
Upgraded our projects (1 project) and it runs ok.
