### PR TITLE
Bug fix/cpp 315 adding cancellation token to generated endpoints

### DIFF
--- a/Dojo.OpenApiGenerator.TestWebApi/Controllers/HelloWorldCustomController.cs
+++ b/Dojo.OpenApiGenerator.TestWebApi/Controllers/HelloWorldCustomController.cs
@@ -5,6 +5,7 @@ using Dojo.OpenApiGenerator.TestWebApi.Generated.Models;
 using Dojo.OpenApiGenerator.TestWebApi.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using System.Threading;
 
 namespace Dojo.OpenApiGenerator.TestWebApi.Controllers
 {
@@ -18,19 +19,19 @@ namespace Dojo.OpenApiGenerator.TestWebApi.Controllers
         }
 
         public override Task<ActionResult<HelloFromSourceApiModel>>
-            HelloFromSourceActionAsync([FromQuery, BindRequired, MaxLength(5)] System.String message, [FromRoute, BindRequired] System.Int64 number)
+            HelloFromSourceActionAsync([FromQuery, BindRequired, MaxLength(5)] System.String message, [FromRoute, BindRequired] System.Int64 number, CancellationToken cancellationToken)
         {
-            return base.HelloFromSourceActionAsync(message, number);
+            return base.HelloFromSourceActionAsync(message, number, cancellationToken);
         }
 
-        protected override async Task<ActionResult<HelloFromSourceApiModel>> HelloFromSourceAsync(string message, long number)
+        protected override async Task<ActionResult<HelloFromSourceApiModel>> HelloFromSourceAsync(string message, long number, CancellationToken cancellationToken)
         {
-            return Ok(await _helloWorldService.HelloFromSourceAsync(number));
+            return Ok(await _helloWorldService.HelloFromSourceAsync(number, cancellationToken));
         }
 
-        protected override async Task<ActionResult<string>> GetHelloGenerated2Async()
+        protected override async Task<ActionResult<string>> GetHelloGenerated2Async(CancellationToken cancellationToken)
         {
-            return Ok(await _helloWorldService.HelloGenerated2Async());
+            return Ok(await _helloWorldService.HelloGenerated2Async(cancellationToken));
         }
     }
 }

--- a/Dojo.OpenApiGenerator.TestWebApi/Dojo.OpenApiGenerator.TestWebApi.csproj
+++ b/Dojo.OpenApiGenerator.TestWebApi/Dojo.OpenApiGenerator.TestWebApi.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework> 
     <!-- If you want to see genereted code, then please uncomment EmitCompilerGeneratedFiles and CompilerGeneratedFilesOutputPath blocks -->
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>  
-    <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
+    <!-- <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>  
+    <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath> -->
     </PropertyGroup>
 
   <ItemGroup>

--- a/Dojo.OpenApiGenerator.TestWebApi/Dojo.OpenApiGenerator.TestWebApi.csproj
+++ b/Dojo.OpenApiGenerator.TestWebApi/Dojo.OpenApiGenerator.TestWebApi.csproj
@@ -1,8 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-  </PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework> 
+    <!-- If you want to see genereted code, then please uncomment EmitCompilerGeneratedFiles and CompilerGeneratedFilesOutputPath blocks -->
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>  
+    <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
+    </PropertyGroup>
 
   <ItemGroup>
     <Compile Remove="OpenApiSchemas\accounts\**" />

--- a/Dojo.OpenApiGenerator.TestWebApi/Services/HelloWorldService.cs
+++ b/Dojo.OpenApiGenerator.TestWebApi/Services/HelloWorldService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Dojo.Generators.Abstractions;
 using Dojo.OpenApiGenerator.TestWebApi.Exceptions;
@@ -9,7 +10,7 @@ namespace Dojo.OpenApiGenerator.TestWebApi.Services
     [AutoInterface]
     public partial class HelloWorldService
     {
-        public Task<Dojo.OpenApiGenerator.TestWebApi.Generated.Models.HelloFromSourceApiModel> HelloFromSourceAsync(long number)
+        public Task<Dojo.OpenApiGenerator.TestWebApi.Generated.Models.HelloFromSourceApiModel> HelloFromSourceAsync(long number, CancellationToken cancellationToken)
         {
             var result = GetHelloFromSourceGeneratedApiModel(number);
 
@@ -21,7 +22,7 @@ namespace Dojo.OpenApiGenerator.TestWebApi.Services
             return Task.FromResult(result);
         }
 
-        public Task<string> HelloGenerated2Async()
+        public Task<string> HelloGenerated2Async(CancellationToken cancellationToken)
         {
             return Task.FromResult("Hello Generated 3");
         }

--- a/Dojo.OpenApiGenerator/CodeTemplates/AbstractControllerTemplate.mustache
+++ b/Dojo.OpenApiGenerator/CodeTemplates/AbstractControllerTemplate.mustache
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.CodeDom.Compiler;
 using System.ComponentModel.DataAnnotations;

--- a/Dojo.OpenApiGenerator/Models/ApiControllerAction.cs
+++ b/Dojo.OpenApiGenerator/Models/ApiControllerAction.cs
@@ -222,6 +222,7 @@ namespace Dojo.OpenApiGenerator.Models
 
                 TryAppendParameterDefaultValue(apiParameter, actionParameterBuilder);
             }
+            AppendCancellationTokenParameterSignature(actionParameterBuilder);
 
             return actionParameterBuilder.ToString();
         }
@@ -268,6 +269,8 @@ namespace Dojo.OpenApiGenerator.Models
                 builder.Append(RequestBody.SourceCodeName);
             }
 
+            AppendCancellationTokenParameter(builder);
+
             return builder.ToString();
         }
 
@@ -309,6 +312,8 @@ namespace Dojo.OpenApiGenerator.Models
                 builder.Append(" ");
                 builder.Append(RequestBody.SourceCodeName);
             }
+
+            AppendCancellationTokenParameterSignature(builder);
 
             return builder.ToString();
         }
@@ -474,5 +479,11 @@ namespace Dojo.OpenApiGenerator.Models
         {
             return $"{constraints} {typeFullName} {parameterName}";
         }
+
+        private static void AppendCancellationTokenParameterSignature(StringBuilder builder)
+            =>  builder.Append(builder.Length > 0 ? $"{InputParametersSeparator}CancellationToken cancellationToken" : "CancellationToken cancellationToken");
+
+        private static void AppendCancellationTokenParameter(StringBuilder builder)
+            =>  builder.Append(builder.Length > 0 ? $"{InputParametersSeparator}cancellationToken" : "cancellationToken");
     }
 }

--- a/Dojo.OpenApiGenerator/Models/ApiControllerAction.cs
+++ b/Dojo.OpenApiGenerator/Models/ApiControllerAction.cs
@@ -173,12 +173,13 @@ namespace Dojo.OpenApiGenerator.Models
 
         private string GetInputActionParametersString()
         {
+            var actionParameterBuilder = new StringBuilder();
+
             if (!HasAnyParameters && !HasRequestBody)
             {
-                return null;
+                AppendCancellationTokenParameterSignature(actionParameterBuilder);
+                return actionParameterBuilder.ToString();
             }
-
-            var actionParameterBuilder = new StringBuilder();
 
             if (HasRequestBody)
             {
@@ -222,6 +223,7 @@ namespace Dojo.OpenApiGenerator.Models
 
                 TryAppendParameterDefaultValue(apiParameter, actionParameterBuilder);
             }
+
             AppendCancellationTokenParameterSignature(actionParameterBuilder);
 
             return actionParameterBuilder.ToString();
@@ -235,12 +237,14 @@ namespace Dojo.OpenApiGenerator.Models
 
         private string GetInputServiceCallParametersString()
         {
+            var builder = new StringBuilder();
+
             if (!HasAnyParameters && !HasRequestBody)
             {
-                return null;
+                AppendCancellationTokenParameter(builder);
+                return builder.ToString();
             }
 
-            var builder = new StringBuilder();
             var index = 0;
 
             var parametersWithoutVersion = AllParameters
@@ -276,12 +280,15 @@ namespace Dojo.OpenApiGenerator.Models
 
         private string GetInputServiceParametersString()
         {
+            var builder = new StringBuilder();
+
             if (!HasAnyParameters && !HasRequestBody)
             {
-                return null;
+                AppendCancellationTokenParameterSignature(builder);
+                return builder.ToString();
             }
 
-            var builder = new StringBuilder();
+            
             var index = 0;
             var parametersWithoutVersion = AllParameters
                 .Where(p => !ExcludeVersionParameter(p))


### PR DESCRIPTION
**JIRA Link**
https://paymentsense.atlassian.net/jira/software/projects/CPP/boards/531?selectedIssue=CPP-315

**What does this PR do?**
This pr is to fix suggested issue

**How does this PR fix it?**
This pr updates the OpenAPISourceGenerator to add the token based on the signature of the endpoint present in the openAPI json

**Evidence**
![Screenshot 2024-02-08 at 15 54 58](https://github.com/dojo-engineering/source-generators/assets/159128436/05dac8c3-4b5c-4b93-b1da-474c7c681245)
![Screenshot 2024-02-08 at 15 55 28](https://github.com/dojo-engineering/source-generators/assets/159128436/510ff6af-09a1-4d41-8bf1-63a19dce8a4f)

