### PR TITLE
remove exception serialization due obsolete api .net 8

### DIFF
--- a/Dojo.AutoGenerators/AutoExceptionGenerator.cs
+++ b/Dojo.AutoGenerators/AutoExceptionGenerator.cs
@@ -66,10 +66,6 @@ namespace {classDefinition.Namespace}
         public {classDefinition.Name}(string message, Exception innerException) : base(message, innerException)
         {{
         }}
-
-        protected {classDefinition.Name}(SerializationInfo info, StreamingContext context) : base(info, context)
-        {{
-        }}
     }}
 }}
 ");

--- a/Dojo.Generators.Tests/AutoExceptionTests.cs
+++ b/Dojo.Generators.Tests/AutoExceptionTests.cs
@@ -42,10 +42,6 @@ namespace Level1.Level2
         public TestException(string message, Exception innerException) : base(message, innerException)
         {{
         }}
-
-        protected TestException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {{
-        }}
     }}
 }}";
             // Act


### PR DESCRIPTION
**Why this PR?**
Remove exception serialization due to .net 8 error:
Error SYSLIB0051 : 'Exception.Exception(SerializationInfo, StreamingContext)' is obsolete: 'This API supports obsolete formatter-based serialization. It should not be called or extended by application code.' (https://aka.ms/dotnet-warnings/SYSLIB0051)
