### PR TITLE
Feature/pppp 1117 make apiexplorer optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ bld/
 #wwwroot/
 
 # Visual Studio 2017 auto generated files
-Generated\ Files/
+**/Generated/ 
 
 # MSTest test Results
 [Tt]est[Rr]esult*/

--- a/Dojo.OpenApiGenerator.TestWebApi/Dojo.OpenApiGenerator.TestWebApi.csproj
+++ b/Dojo.OpenApiGenerator.TestWebApi/Dojo.OpenApiGenerator.TestWebApi.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework> 
     <!-- If you want to see genereted code, then please uncomment EmitCompilerGeneratedFiles and CompilerGeneratedFilesOutputPath blocks -->
     <!-- <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>  
-    <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath> -->
+    <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>-->
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 

--- a/Dojo.OpenApiGenerator.TestWebApi/autoApiGeneratorSettings.json
+++ b/Dojo.OpenApiGenerator.TestWebApi/autoApiGeneratorSettings.json
@@ -3,5 +3,6 @@
   "IncludeVersionParameterInActionSignature": false,
   "OpenApiSupportedVersionsExtension": "x-supported-api-versions",
   "DateTimeVersionFormat": "yyyy-MM-dd",
-  "ApiAuthorizationPoliciesExtension": "x-authorization-policies"
+  "ApiAuthorizationPoliciesExtension": "x-authorization-policies",
+  "GenerateApiExplorer": false
 }

--- a/Dojo.OpenApiGenerator/AutoApiGenerator.cs
+++ b/Dojo.OpenApiGenerator/AutoApiGenerator.cs
@@ -63,8 +63,8 @@ namespace Dojo.OpenApiGenerator
                 _autoApiGeneratorSettings = AutoApiGeneratorSettings.GetAutoApiGeneratorSettings(_projectDir);
                 var projectNamespace = context.GetProjectDefaultNamespace();
                 var apisToOverride = new List<string>();
-            
-                GenerateApiConfiguratorSourceCode(context, projectNamespace);
+
+                GenerateApiConfiguratorSourceCode(context, projectNamespace, _autoApiGeneratorSettings.GenerateApiExplorer);
                 GenerateInheritedApiVersionAttributeSourceCode(context, projectNamespace);
                 GenerateApisSourceCode(context, apisToOverride, projectNamespace);  
             }
@@ -89,12 +89,12 @@ namespace Dojo.OpenApiGenerator
             GenerateApiVersionsSourceCode(context, projectNamespace);
         }
 
-        private void GenerateApiConfiguratorSourceCode(GeneratorExecutionContext context, string projectNamespace)
+        private void GenerateApiConfiguratorSourceCode(GeneratorExecutionContext context, string projectNamespace, bool generateApiExplorer)
         {
             _apiConfiguratorTemplateString ??= Templates.ReadTemplate(Templates.ApiConfiguratorTemplate);
 
             const string fileName = "ApiConfigurator.g.cs";
-            var source = _stubbleBuilder.Render(_apiConfiguratorTemplateString, new BasicClass(projectNamespace));
+            var source = _stubbleBuilder.Render(_apiConfiguratorTemplateString, new BasicClass(projectNamespace, generateApiExplorer));
 
             context.AddSource(fileName, SourceText.From(source, Encoding.UTF8));
         }

--- a/Dojo.OpenApiGenerator/CodeTemplates/ApiConfiguratorTemplate.mustache
+++ b/Dojo.OpenApiGenerator/CodeTemplates/ApiConfiguratorTemplate.mustache
@@ -32,8 +32,11 @@ namespace {{ProjectNamespace}}.Generated.StartupConfiguration
                     options.ApiVersionReader = versionReader ?? new HeaderApiVersionReader(versionHeaderName);
                     options.ReportApiVersions = reportApiVersions;
                 })
-                .AddMvc()
-                .AddApiExplorer();
+                .AddMvc();
+
+{{#GenerateApiExplorer}}
+            services.AddApiExplorer();
+{{/GenerateApiExplorer}}
 
             foreach (var apiVersion in ApiConstants.ApiVersions)
             {

--- a/Dojo.OpenApiGenerator/CodeTemplates/ApiConfiguratorTemplate.mustache
+++ b/Dojo.OpenApiGenerator/CodeTemplates/ApiConfiguratorTemplate.mustache
@@ -24,7 +24,7 @@ namespace {{ProjectNamespace}}.Generated.StartupConfiguration
             bool assumeDefaultVersionWhenUnspecified = true,
             bool reportApiVersions = true)
         {
-            services
+            var versioningBuilder = services
                 .AddApiVersioning(options =>
                 {
                     options.AssumeDefaultVersionWhenUnspecified = assumeDefaultVersionWhenUnspecified;
@@ -35,7 +35,7 @@ namespace {{ProjectNamespace}}.Generated.StartupConfiguration
                 .AddMvc();
 
 {{#GenerateApiExplorer}}
-            services.AddApiExplorer();
+            versioningBuilder.AddApiExplorer();
 {{/GenerateApiExplorer}}
 
             foreach (var apiVersion in ApiConstants.ApiVersions)

--- a/Dojo.OpenApiGenerator/Configuration/AutoApiGeneratorSettings.cs
+++ b/Dojo.OpenApiGenerator/Configuration/AutoApiGeneratorSettings.cs
@@ -6,9 +6,13 @@ namespace Dojo.OpenApiGenerator.Configuration
     internal class AutoApiGeneratorSettings
     {
         public string VersionParameterName { get; set; }
+        
         public bool IncludeVersionParameterInActionSignature { get; set; }
+        
         public string OpenApiSupportedVersionsExtension { get; set; }
+        
         public string DateTimeVersionFormat { get; set; }
+        
         public string ApiAuthorizationPoliciesExtension { get; set; }
 
         public bool GenerateApiExplorer { get; set; } = true;

--- a/Dojo.OpenApiGenerator/Configuration/AutoApiGeneratorSettings.cs
+++ b/Dojo.OpenApiGenerator/Configuration/AutoApiGeneratorSettings.cs
@@ -11,6 +11,8 @@ namespace Dojo.OpenApiGenerator.Configuration
         public string DateTimeVersionFormat { get; set; }
         public string ApiAuthorizationPoliciesExtension { get; set; }
 
+        public bool GenerateApiExplorer { get; set; } = true;
+
         public static AutoApiGeneratorSettings GetAutoApiGeneratorSettings(string projectDir)
         {
             var settingFilePath = $"{projectDir}/{Constants.AutoApiGeneratorSettingsFile}";

--- a/Dojo.OpenApiGenerator/Models/BasicClass.cs
+++ b/Dojo.OpenApiGenerator/Models/BasicClass.cs
@@ -2,8 +2,11 @@
 {
     internal class BasicClass : BaseGeneratedCodeModel
     {
-        public BasicClass(string projectNamespace) : base(projectNamespace)
+        public BasicClass(string projectNamespace, bool generateApiExplorer = false) : base(projectNamespace)
         {
+            generateApiExplorer = GenerateApiExplorer;
         }
+
+        public bool GenerateApiExplorer { get; private set; }
     }
 }

--- a/Dojo.OpenApiGenerator/Models/BasicClass.cs
+++ b/Dojo.OpenApiGenerator/Models/BasicClass.cs
@@ -4,7 +4,7 @@
     {
         public BasicClass(string projectNamespace, bool generateApiExplorer = false) : base(projectNamespace)
         {
-            generateApiExplorer = GenerateApiExplorer;
+            GenerateApiExplorer = generateApiExplorer;
         }
 
         public bool GenerateApiExplorer { get; private set; }

--- a/Dojo.OpenApiGenerator/autoApiGeneratorSettings.json.sample
+++ b/Dojo.OpenApiGenerator/autoApiGeneratorSettings.json.sample
@@ -19,5 +19,7 @@
        "Sec2"
      ]
    */
-  "ApiAuthorizationPoliciesExtension": "x-authorization-policies"
+  "ApiAuthorizationPoliciesExtension": "x-authorization-policies",
+  /* This will prevent swagger open api explorer generation*/
+  "GenerateApiExplorer": false
 }


### PR DESCRIPTION
**Why this PR?**
Disable generating `AddApiExplorer` in order to build projects depending on the OpenAPI generator.

**How does the PR achieve that?**
Adds a setting to control this, which keeps the default behavior.

**How do I test this?**
Using the test project provided (should have some test though 😢)