### PR TITLE
generic method type constraints

### DIFF
--- a/Dojo.AutoGenerators/AutoInterfaceGenerator.cs
+++ b/Dojo.AutoGenerators/AutoInterfaceGenerator.cs
@@ -128,8 +128,7 @@ namespace Dojo.AutoGenerators
         public static string GetGenericTypeConstraints(IMethodSymbol method)
         {
             if (!method.IsGenericMethod
-                || method.TypeParameters.Length == 0
-                || method.TypeParameters[0].ConstraintTypes.Length == 0)
+                || method.TypeParameters.Length == 0)
             {
                 return string.Empty;
             }
@@ -141,6 +140,16 @@ namespace Dojo.AutoGenerators
                 {
                     bdr.AppendLine();
                     bdr.Append($"           where {typeParam.Name} : {string.Join(", ", typeParam.ConstraintTypes.Select(x => x.ToDisplayString()))}");
+                }
+                else if (typeParam.HasReferenceTypeConstraint)
+                {
+                    bdr.AppendLine();
+                    bdr.Append($"           where {typeParam.Name} : class");
+                }
+                else if (typeParam.HasValueTypeConstraint)
+                {
+                    bdr.AppendLine();
+                    bdr.Append($"           where {typeParam.Name} : struct");
                 }
             }
 


### PR DESCRIPTION
We are currently allowing generic method parameters, but if you have generic type constraints in your method => the build fails

this change will ensure that it can generated interfaces like this:

![image](https://github.com/user-attachments/assets/2b03d2cd-bfc4-44ee-b09a-696786fb2700)

it also allows for multiple generic types with constraints

